### PR TITLE
Clear recv buffer by start byte

### DIFF
--- a/tfrog-motordriver/communication.c
+++ b/tfrog-motordriver/communication.c
@@ -852,6 +852,12 @@ static inline int data_analyze_(
       receive_period = 1;
       state = STATE_IDLE;
     }
+
+    if (len == 0 && !receive_period)
+    {
+      // Line buffer is cleared. Move receive pointer to the current position.
+      *r_receive_buf = r_buf;
+    }
     data++;
     r_buf++;
     if (r_buf >= RECV_BUF_LEN)
@@ -860,7 +866,10 @@ static inline int data_analyze_(
       data = receive_buf;
     }
     if (receive_period)
+    {
+      // Line is end. Move receive pointer to the next position.
       *r_receive_buf = r_buf;
+    }
   }
   if (send_buf_pos485 > 0)
   {

--- a/tfrog-motordriver/main.c
+++ b/tfrog-motordriver/main.c
@@ -88,6 +88,8 @@ Tfrog_EEPROM_data saved_param = TFROG_EEPROM_DEFAULT;
 
 extern unsigned char languageIdStringDescriptor[];
 extern USBDDriverDescriptors cdcdSerialDriverDescriptors;
+extern volatile int w_receive_buf;
+extern volatile int r_receive_buf;
 
 unsigned char manufacturerStringDescriptor2[64] = {
   USBStringDescriptor_LENGTH(0),
@@ -963,14 +965,14 @@ int main()
 
     if (usb_read_pause)
     {
-      printf("USB:flush\n\r");
+      printf("USB:flush r:%d,w:%d\n\r", r_receive_buf, w_receive_buf);
     }
     data_analyze();
 
     if (usb_read_pause)
     {
       usb_read_pause = 0;
-      printf("USB:resume\n\r");
+      printf("USB:resume r:%d,w:%d\n\r", r_receive_buf, w_receive_buf);
       CDCDSerialDriver_Read(usbBuffer, DATABUFFERSIZE, (TransferCallback)UsbDataReceived, 0);
     }
 


### PR DESCRIPTION
Sending stream with periodic START_BYTEs without END_BYTE, like following, made the incoming data processing buffer stacked.
```
	@`@@@@@	@`@@@@@	@`@@@@@	@`@@@@@	@`@@@@@	@`@@@@@	@`@@@@@	@`@@@@@	@`@@@@@	@`@@@@@	@`@@@@@	@`@@@@@	@`@@@@@	@`@@@@@	@`@@@@@	@`@@@
```
(Some USB host controller or kernel module seems repeating last data after closing device.)

This PR clears buffer if START_BYTE is arrived.