### PR TITLE
Fix signal collision on PWM_ENABLE pin

### DIFF
--- a/at91lib/boards/tfrog-rev4/board.h
+++ b/at91lib/boards/tfrog-rev4/board.h
@@ -225,9 +225,9 @@
   }
 //------------------------------------------------------------------------------
 
-#define PIN_PWM_ENABLE                                                 \
-  {                                                                    \
-    1 << 16, AT91C_BASE_PIOC, AT91C_ID_PIOC, PIO_OUTPUT_1, PIO_DEFAULT \
+#define PIN_PWM_ENABLE                                             \
+  {                                                                \
+    1 << 16, AT91C_BASE_PIOC, AT91C_ID_PIOC, PIO_INPUT, PIO_PULLUP \
   }
 
 #define PIN_PWM_CYCLE                                              \

--- a/at91lib/boards/tfrog-rev5/board.h
+++ b/at91lib/boards/tfrog-rev5/board.h
@@ -251,9 +251,9 @@
   }
 //------------------------------------------------------------------------------
 
-#define PIN_PWM_ENABLE                                                 \
-  {                                                                    \
-    1 << 16, AT91C_BASE_PIOC, AT91C_ID_PIOC, PIO_OUTPUT_1, PIO_DEFAULT \
+#define PIN_PWM_ENABLE                                             \
+  {                                                                \
+    1 << 16, AT91C_BASE_PIOC, AT91C_ID_PIOC, PIO_INPUT, PIO_PULLUP \
   }
 
 #define PIN_PWM_CYCLE                                                 \

--- a/tfrog-motordriver/controlPWM.c
+++ b/tfrog-motordriver/controlPWM.c
@@ -40,9 +40,6 @@
 
 static const Pin pinPWMCycle2 = PIN_PWM_CYCLE2;
 
-// / PWM Enable pin instance.
-static const Pin pinPWMEnable = PIN_PWM_ENABLE;
-
 #define SinTB_2PI  4096
 #define AtanTB_LEN 512
 
@@ -727,5 +724,4 @@ void controlPWM_init()
 
   THEVA.GENERAL.PWM.COUNT_ENABLE = 1;
   THEVA.GENERAL.OUTPUT_ENABLE = 1;
-  PIO_Clear(&pinPWMEnable);
 }

--- a/tfrog-motordriver/main.c
+++ b/tfrog-motordriver/main.c
@@ -124,6 +124,9 @@ char connected = 0;
 
 // / List of pins that must be configured for use by the application.
 static const Pin pins[] = {
+    // PIN_PWM_ENABLE was originally intended to be a PWM output enable signal sent to FPGA.
+    // However, FPGA logic of TF-2MD3-R5/6 doesn't read this pin and also outputs a signal.
+    // PWM_ENABLE pin is currently unused and setup as an input.
     PIN_PWM_ENABLE,
     PIN_PCK_PCK1,
     PINS_USERIO,
@@ -140,9 +143,6 @@ static const Pin pinVer[] = {PIN_VERSION};
 
 // / VBus pin instance.
 static const Pin pinVbus = PIN_USB_VBUS;
-
-// / PWM Enable pin instance.
-const Pin pinPWMEnable = PIN_PWM_ENABLE;
 
 // / Buffer for storing incoming USB data.
 static uint8_t usbBuffer[DATABUFFERSIZE];
@@ -406,9 +406,6 @@ int main()
 
   // If they are present, configure Vbus & Wake-up pins
   PIO_InitializeInterrupts(0);
-
-  // Disable PWM Output
-  PIO_Set(&pinPWMEnable);
 
   printf("SRAM init\n\r");
   SRAM_Init();


### PR DESCRIPTION
PIN_PWM_ENABLE was originally intended to be a PWM output enable signal sent to FPGA. However, FPGA logic of TF-2MD3-R5/6 doesn't read this pin and also outputs a signal. Setup PWM_ENABLE pin as an input and don't output signal from MCU.

Tested both on TF-2MD3-R5 and TF-2MD3-R6 and confirmed that PWM output is enabled and motor is controlled.