### PR TITLE
Support high resolution encoder

### DIFF
--- a/tfrog-motordriver/controlPWM.c
+++ b/tfrog-motordriver/controlPWM.c
@@ -135,9 +135,13 @@ void controlPWM_config(int32_t i)
 
   // Interrupt interval should be less than 1%(= 3.6deg of phase error) of
   // hall signal edge interval.
+  // Original expression:
+  //   motor_param[i].vel_rely_hall =
+  //       motor_param[i].enc_rev * 48000 /
+  //       (2 * PWM_resolution * driver_param.control_cycle * 100);
   motor_param[i].vel_rely_hall =
       motor_param[i].enc_rev * (48000 / (2 * 100)) /
-(PWM_resolution * driver_param.control_cycle);
+      (PWM_resolution * driver_param.control_cycle);
 
   motor_param[i].enc_mul =
       (int32_t)((int64_t)SinTB_2PI * 0x40000 * motor_param[i].enc_denominator /

--- a/tfrog-motordriver/controlPWM.c
+++ b/tfrog-motordriver/controlPWM.c
@@ -136,8 +136,8 @@ void controlPWM_config(int32_t i)
   // Interrupt interval should be less than 1%(= 3.6deg of phase error) of
   // hall signal edge interval.
   motor_param[i].vel_rely_hall =
-      (int64_t)motor_param[i].enc_rev * 48000 /
-      (2 * PWM_resolution * driver_param.control_cycle * 100);
+      motor_param[i].enc_rev * (48000 / (2 * 100)) /
+(PWM_resolution * driver_param.control_cycle);
 
   motor_param[i].enc_mul =
       (int32_t)((int64_t)SinTB_2PI * 0x40000 * motor_param[i].enc_denominator /

--- a/tfrog-motordriver/controlPWM.c
+++ b/tfrog-motordriver/controlPWM.c
@@ -136,7 +136,7 @@ void controlPWM_config(int32_t i)
   // Interrupt interval should be less than 1%(= 3.6deg of phase error) of
   // hall signal edge interval.
   motor_param[i].vel_rely_hall =
-      motor_param[i].enc_rev * 48000 /
+      (int64_t)motor_param[i].enc_rev * 48000 /
       (2 * PWM_resolution * driver_param.control_cycle * 100);
 
   motor_param[i].enc_mul =


### PR DESCRIPTION
The variable `.enc_rev` stores the number of encoder pulses for 360 electrical degrees. It is defined as an int32_t type. However, because we multiply it directly by `48000`, it overflows if the encoder has too many pulses. Specifically, it overflows if the count is more than the number of pole pairs x 44,739.

I checked other parts of the calculation and confirmed they have enough room. Therefore, by casting just this part, the encoder resolution we can support will increase a lot.